### PR TITLE
Add first MythX config and CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,12 @@ executors:
     resource_class: medium
     working_directory: ~/project
 
+  med_py:
+    docker:
+      - image: circleci/python:3.8
+    resource_class: medium
+    working_directory: ~/project
+
   release: # 1cpu, 2G ram
     docker:
       - image: cibuilds/github:0.13.0
@@ -125,6 +131,19 @@ jobs:
           command: |
             yarn run lint:app
 
+  run_mythx:
+    executor: med_py
+    steps:
+      - prepare
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: Install MythX CLI
+          command: pip install mythx-cli
+      - run:
+          name: Analyze with MythX
+          command: mythx analyze
+  
   test_contracts:
     executor: med
     steps:

--- a/.mythx.yml
+++ b/.mythx.yml
@@ -1,0 +1,27 @@
+# Run me by typing `mythx analyze` in the directory of the yml file! :)
+
+ci: true
+confirm: true
+analyze:
+    mode: quick
+    async: false
+    create-group: true
+    solc: 0.5.9
+    remappings:
+        - "@openzeppelin=node_modules/@openzeppelin"
+    targets:
+      - contracts/AccountIngress.sol:AccountIngress
+      - contracts/AccountRulesList.sol:AccountRulesList
+      - contracts/AccountRulesProxy.sol:AccountRulesProxy
+      - contracts/AccountRules.sol:AccountRules
+      - contracts/AdminList.sol:AdminList
+      - contracts/AdminProxy.sol:AdminProxy
+      - contracts/Admin.sol:Admin
+      - contracts/ExposedAccountRulesList.sol:ExposedAccountRulesList
+      - contracts/ExposedAdminList.sol:ExposedAdminList
+      - contracts/ExposedNodeRulesList.sol:ExposedNodeRulesList
+      - contracts/Ingress.sol:Ingress
+      - contracts/NodeIngress.sol:NodeIngress
+      - contracts/NodeRulesList.sol:NodeRulesList
+      - contracts/NodeRulesProxy.sol:NodeRulesProxy
+      - contracts/NodeRules.sol:NodeRules


### PR DESCRIPTION
(replaces https://github.com/ConsenSys/permissioning-smart-contracts/pull/187)

This pr introduces two changes:

1. An update to the Circle CI configuration which will run a MythX standard scan
2. An all new `.mythx.yaml` which will take the contracts in this repository, compile them, and submit them to MythX for analysis.


### To Do

- [x] [Set up environment variable](https://mythx-cli.readthedocs.io/en/latest/usage.html#using-api-tokens) with valid MythX API key available on CI jobs for the master branch

---

###  References
- MythX docs: https://docs.mythx.io
- MythX CLI docs: https://mythx-cli.readthedocs.io/en/latest/