### PR TITLE
removed deprecated environment variables

### DIFF
--- a/scripts/allowlist_utils.js
+++ b/scripts/allowlist_utils.js
@@ -46,19 +46,11 @@ function isInitialAllowlistedAccountsAvailable() {
     if (process.env.INITIAL_ALLOWLISTED_ACCOUNTS) {
         return process.env.INITIAL_ALLOWLISTED_ACCOUNTS;
     }
-    if (process.env.INITIAL_WHITELISTED_ACCOUNTS) {
-        console.warn("INITIAL_WHITELISTED_ACCOUNTS has been deprecated. Please use INITIAL_ALLOWLISTED_ACCOUNTS instead.");
-        return process.env.INITIAL_WHITELISTED_ACCOUNTS;
-    }
 }
 
 function isInitialAllowlistedNodesAvailable() {
     if (process.env.INITIAL_ALLOWLISTED_NODES) {
         return process.env.INITIAL_ALLOWLISTED_NODES;
-    }
-    if (process.env.INITIAL_WHITELISTED_NODES) {
-        console.warn("INITIAL_WHITELISTED_NODES has been deprecated. Please use INITIAL_ALLOWLISTED_NODES instead.");
-        return process.env.INITIAL_WHITELISTED_NODES;
     }
 }
 


### PR DESCRIPTION
Remove processing of deprecated environment variables, namely `INITIAL_WHITELISTED_NODES` and `INITIAL_WHITELISTED_ACCOUNTS`. 
These are now `INITIAL_ALLOWLISTED_NODES` and `INITIAL_ALLOWLISTED_ACCOUNTS` respectively.
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>