### PR TITLE
Separate Node storage from Node Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ONLY use these instructions if you are doing development work on the Dapp itself
 This is the easiest way to get started for development with the permissioning Dapp:
 
 #### Compile and migrate the contracts (Development mode) ####
-1. Delete your environment variables named `NODE_INGRESS_CONTRACT_ADDRESS`, `ACCOUNT_INGRESS_CONTRACT_ADDRESS`, `ACCOUNT_STORAGE_CONTRACT_ADDRESS` AND
+1. Delete your environment variables named `NODE_INGRESS_CONTRACT_ADDRESS`, `ACCOUNT_INGRESS_CONTRACT_ADDRESS`, `ACCOUNT_STORAGE_CONTRACT_ADDRESS`, `NODE_STORAGE_CONTRACT_ADDRESS` AND
 `CHAIN_ID` - you might need to restart your terminal session to have your changes applied. If you are using a `.env` file, you can comment out the variables.
 1. Start a terminal session and start a Truffle Ganache node running `truffle develop`. This will start a Ganache node and create a Truffle console session.
 1. In the truffle console, run all migrations from scratch with `migrate --reset`. Keep this terminal session open to maintain your Ganache node running.

--- a/contracts/ExposedNodeRulesList.sol
+++ b/contracts/ExposedNodeRulesList.sol
@@ -1,13 +1,13 @@
 pragma solidity 0.5.9;
 
 import "./NodeRulesList.sol";
-import "./NodeRulesListEternalStorage.sol";
+import "./NodeStorage.sol";
 
 
 contract ExposedNodeRulesList is NodeRulesList {
 
-    function _setStorage(NodeRulesListEternalStorage _eternalStorage) public {
-        return setStorage(_eternalStorage);
+    function _setStorage(NodeStorage _storage) public {
+        return setStorage(_storage);
     }
 
     function _calculateKey(string calldata _enodeId, string calldata _ip, uint16 _port) external view returns(uint256) {

--- a/contracts/ExposedNodeRulesList.sol
+++ b/contracts/ExposedNodeRulesList.sol
@@ -1,11 +1,16 @@
 pragma solidity 0.5.9;
 
 import "./NodeRulesList.sol";
+import "./NodeRulesListEternalStorage.sol";
 
 
 contract ExposedNodeRulesList is NodeRulesList {
 
-    function _calculateKey(string calldata _enodeId, string calldata _ip, uint16 _port) external pure returns(uint256) {
+    function _setStorage(NodeRulesListEternalStorage _eternalStorage) public {
+        return setStorage(_eternalStorage);
+    }
+
+    function _calculateKey(string calldata _enodeId, string calldata _ip, uint16 _port) external view returns(uint256) {
         return calculateKey(_enodeId, _ip, _port);
     }
 

--- a/contracts/NodeRules.sol
+++ b/contracts/NodeRules.sol
@@ -43,7 +43,8 @@ contract NodeRules is NodeRulesProxy, NodeRulesList {
         _;
     }
 
-    constructor (NodeIngress _nodeIngressAddress) public {
+    constructor (NodeIngress _nodeIngressAddress, NodeRulesListEternalStorage _eternalStorage) public {
+        setStorage(_eternalStorage);
         nodeIngressContract = _nodeIngressAddress;
     }
 
@@ -132,13 +133,6 @@ contract NodeRules is NodeRulesProxy, NodeRulesList {
 
     function getSize() external view returns (uint) {
         return size();
-    }
-
-    function getByIndex(uint index) external view returns (string memory enodeId, string memory ip, uint16 port) {
-        if (index >= 0 && index < size()) {
-            enode memory item = allowlist[index];
-            return (item.enodeId, item.ip, item.port);
-        }
     }
 
     function triggerRulesChangeEvent(bool addsRestrictions) public {

--- a/contracts/NodeRules.sol
+++ b/contracts/NodeRules.sol
@@ -43,8 +43,8 @@ contract NodeRules is NodeRulesProxy, NodeRulesList {
         _;
     }
 
-    constructor (NodeIngress _nodeIngressAddress, NodeRulesListEternalStorage _eternalStorage) public {
-        setStorage(_eternalStorage);
+    constructor (NodeIngress _nodeIngressAddress, NodeStorage _storage) public {
+        setStorage(_storage);
         nodeIngressContract = _nodeIngressAddress;
     }
 

--- a/contracts/NodeRules.sol
+++ b/contracts/NodeRules.sol
@@ -26,7 +26,7 @@ contract NodeRules is NodeRulesProxy, NodeRulesList {
     // this will be used to protect data when upgrading contracts
     bool readOnlyMode = false;
     // version of this contract: semver like 1.2.14 represented like 001002014
-    uint version = 1000000;
+    uint version = 3000000;
 
     NodeIngress private nodeIngressContract;
 

--- a/contracts/NodeRulesList.sol
+++ b/contracts/NodeRulesList.sol
@@ -41,4 +41,8 @@ contract NodeRulesList {
     function calculateKey(string memory _enodeId, string memory _ip, uint16 _port) public view returns(uint256) {
         return eternalStorage.calculateKey(_enodeId, _ip, _port);
     }
+
+    function getByIndex(uint index) external view returns (string memory enodeId, string memory ip, uint16 port) {
+        return eternalStorage.getByIndex(index);
+    }
 }

--- a/contracts/NodeRulesList.sol
+++ b/contracts/NodeRulesList.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.5.9;
 
-import "./NodeRulesListEternalStorage.sol";
+import "./NodeStorage.sol";
 
 
 contract NodeRulesList {
@@ -12,37 +12,37 @@ contract NodeRulesList {
         uint16 port;
     }
 
-    NodeRulesListEternalStorage private eternalStorage;
+    NodeStorage private nodeStorage;
 
-    function setStorage(NodeRulesListEternalStorage _eternalStorage) internal {
-        eternalStorage = _eternalStorage;
+    function setStorage(NodeStorage _storage) internal {
+        nodeStorage = _storage;
     }
 
     function upgradeVersion(address _newVersion) internal {
-        eternalStorage.upgradeVersion(_newVersion);
+        nodeStorage.upgradeVersion(_newVersion);
     }
 
     function size() internal view returns (uint256) {
-        return eternalStorage.size();
+        return nodeStorage.size();
     }
 
     function exists(string memory _enodeId, string memory _ip, uint16 _port) internal view returns (bool) {
-        return eternalStorage.exists(_enodeId, _ip, _port);
+        return nodeStorage.exists(_enodeId, _ip, _port);
     }
 
     function add(string memory _enodeId, string memory _ip, uint16 _port) public returns (bool) {
-        return eternalStorage.add(_enodeId, _ip, _port);
+        return nodeStorage.add(_enodeId, _ip, _port);
     }
 
     function remove(string memory _enodeId, string memory _ip, uint16 _port) public returns (bool) {
-        return eternalStorage.remove(_enodeId, _ip, _port);
+        return nodeStorage.remove(_enodeId, _ip, _port);
     }
 
     function calculateKey(string memory _enodeId, string memory _ip, uint16 _port) public view returns(uint256) {
-        return eternalStorage.calculateKey(_enodeId, _ip, _port);
+        return nodeStorage.calculateKey(_enodeId, _ip, _port);
     }
 
     function getByIndex(uint index) external view returns (string memory enodeId, string memory ip, uint16 port) {
-        return eternalStorage.getByIndex(index);
+        return nodeStorage.getByIndex(index);
     }
 }

--- a/contracts/NodeRulesListEternalStorage.sol
+++ b/contracts/NodeRulesListEternalStorage.sol
@@ -1,0 +1,104 @@
+pragma solidity 0.5.9;
+
+import "./Admin.sol";
+import "./NodeIngress.sol";
+
+
+contract NodeRulesListEternalStorage {
+    event VersionChange(
+        address oldAddress,
+        address newAddress
+    );
+    // initialize this to the deployer of this contract
+    address private latestVersion = msg.sender;
+    address private owner = msg.sender;
+
+    NodeIngress private ingressContract;
+
+
+
+    // struct size = 82 bytes
+    struct enode {
+        string enodeId;
+        string ip;
+        uint16 port;
+    }
+
+    enode[] public allowlist;
+    mapping (uint256 => uint256) private indexOf; //1-based indexing. 0 means non-existent
+
+    constructor (NodeIngress _ingressContract) public {
+        ingressContract = _ingressContract;
+    }
+
+    modifier onlyLatestVersion() {
+        require(msg.sender == latestVersion, "only the latestVersion can modify the list");
+        _;
+    }
+
+    modifier onlyAdmin() {
+        if (address(0) == address(ingressContract)) {
+            require(msg.sender == owner, "only owner permitted since ingressContract is explicitly set to zero");
+        } else {
+            address adminContractAddress = ingressContract.getContractAddress(ingressContract.ADMIN_CONTRACT());
+
+            require(adminContractAddress != address(0), "Ingress contract must have Admin contract registered");
+            require(Admin(adminContractAddress).isAuthorized(msg.sender), "Sender not authorized");
+        }
+        _;
+    }
+
+    function upgradeVersion(address _newVersion) public onlyAdmin {
+        emit VersionChange(latestVersion, _newVersion);
+        latestVersion = _newVersion;
+    }
+
+    function size() public view returns (uint256) {
+        return allowlist.length;
+    }
+
+    function exists(string memory _enodeId, string memory _ip, uint16 _port) public view returns (bool) {
+        return indexOf[calculateKey(_enodeId, _ip, _port)] != 0;
+    }
+
+    function add(string memory _enodeId, string memory _ip, uint16 _port) public returns (bool) {
+        uint256 key = calculateKey(_enodeId, _ip, _port);
+        if (indexOf[key] == 0) {
+            indexOf[key] = allowlist.push(enode(_enodeId, _ip, _port));
+            return true;
+        }
+        return false;
+    }
+
+    function remove(string memory _enodeId, string memory _ip, uint16 _port) public returns (bool) {
+        uint256 key = calculateKey(_enodeId, _ip, _port);
+        uint256 index = indexOf[key];
+
+        if (index > 0 && index <= allowlist.length) { //1 based indexing
+            //move last item into index being vacated (unless we are dealing with last index)
+            if (index != allowlist.length) {
+                enode memory lastEnode = allowlist[allowlist.length - 1];
+                allowlist[index - 1] = lastEnode;
+                indexOf[calculateKey(lastEnode.enodeId, lastEnode.ip, lastEnode.port)] = index;
+            }
+
+            //shrink array
+            allowlist.length -= 1; // mythx-disable-line SWC-101
+            indexOf[key] = 0;
+            return true;
+        }
+
+        return false;
+    }
+
+    function getByIndex(uint index) external view returns (string memory enodeId, string memory ip, uint16 port) {
+        if (index >= 0 && index < size()) {
+            enode memory item = allowlist[index];
+            return (item.enodeId, item.ip, item.port);
+        }
+    }
+
+    function calculateKey(string memory _enodeId, string memory _ip, uint16 _port) public pure returns(uint256) {
+        return uint256(keccak256(abi.encodePacked(_enodeId, _ip, _port)));
+    }
+}

--- a/contracts/NodeStorage.sol
+++ b/contracts/NodeStorage.sol
@@ -4,7 +4,7 @@ import "./Admin.sol";
 import "./NodeIngress.sol";
 
 
-contract NodeRulesListEternalStorage {
+contract NodeStorage {
     event VersionChange(
         address oldAddress,
         address newAddress

--- a/migrations/3_deploy_node_ingress_rules_contract.js
+++ b/migrations/3_deploy_node_ingress_rules_contract.js
@@ -11,7 +11,7 @@ const rulesContractName = Web3Utils.utf8ToHex("rules");
 
 /* The address of the node ingress contract if pre deployed */
 let nodeIngress = process.env.NODE_INGRESS_CONTRACT_ADDRESS;
-/* The address of the node ingress contract if pre deployed */
+/* The address of the node storage contract if pre deployed */
 let nodeStorage = process.env.NODE_STORAGE_CONTRACT_ADDRESS;
 let retainCurrentRulesContract = AllowlistUtils.getRetainNodeRulesContract();
 

--- a/migrations/3_deploy_node_ingress_rules_contract.js
+++ b/migrations/3_deploy_node_ingress_rules_contract.js
@@ -3,7 +3,7 @@ const AllowlistUtils = require('../scripts/allowlist_utils');
 
 const Rules = artifacts.require("./NodeRules.sol");
 const NodeIngress = artifacts.require("./NodeIngress.sol");
-const NodeRulesListEternalStorage = artifacts.require("./NodeRulesListEternalStorage.sol");
+const NodeStorage = artifacts.require("./NodeStorage.sol");
 const Admin = artifacts.require("./Admin.sol");
 
 const adminContractName = Web3Utils.utf8ToHex("administration");
@@ -46,12 +46,12 @@ module.exports = async(deployer, network) => {
     var storageInstance;
     if (! nodeStorage) {
         // Only deploy if we haven't been provided a pre-deployed address
-        storageInstance = await deployer.deploy(NodeRulesListEternalStorage, nodeIngress);
-        console.log("   > Deployed NodeStorage contract to address = " + NodeRulesListEternalStorage.address);
-        nodeStorage = NodeRulesListEternalStorage.address;
+        storageInstance = await deployer.deploy(NodeStorage, nodeIngress);
+        console.log("   > Deployed NodeStorage contract to address = " + NodeStorage.address);
+        nodeStorage = NodeStorage.address;
     } else {
         // is there a storage already deployed
-        storageInstance = await NodeRulesListEternalStorage.at(nodeStorage);
+        storageInstance = await NodeStorage.at(nodeStorage);
         console.log(">>> Using existing NodeStorage " + storageInstance.address);
         // TODO check that this contract is a storage contract eg call a method
     }

--- a/migrations/3_deploy_node_ingress_rules_contract.js
+++ b/migrations/3_deploy_node_ingress_rules_contract.js
@@ -42,8 +42,6 @@ module.exports = async(deployer, network) => {
     await nodeIngressInstance.setContractAddress(adminContractName, admin.address);
     console.log("   > Updated NodeIngress with Admin  address = " + admin.address);
 
-    let nodeRulesContract = await Rules.deployed();
-
     // STORAGE
     var storageInstance;
     if (! nodeStorage) {
@@ -75,7 +73,7 @@ module.exports = async(deployer, network) => {
             let enode = allowlistedNodes[i];
             const { enodeId, ip, port } = AllowlistUtils.enodeToParams(enode);
             
-            let result = await nodeRulesContract.addEnode(
+            let result = await Rules.addEnode(
                 enodeId,
                 ip,    
                 Web3Utils.toBN(port)

--- a/migrations/3_deploy_node_ingress_rules_contract.js
+++ b/migrations/3_deploy_node_ingress_rules_contract.js
@@ -60,7 +60,7 @@ module.exports = async(deployer, network) => {
     await deployer.deploy(Rules, nodeIngress, nodeStorage);
     console.log("   > Rules deployed with NodeIngress.address = " + nodeIngress + "\n   > and storageAddress = " + nodeStorage);
     console.log("   > Rules.address " + Rules.address);
-
+    let nodeRulesContract = await Rules.deployed();
     
 
     await nodeIngressInstance.setContractAddress(rulesContractName, Rules.address);
@@ -73,7 +73,7 @@ module.exports = async(deployer, network) => {
             let enode = allowlistedNodes[i];
             const { enodeId, ip, port } = AllowlistUtils.enodeToParams(enode);
             
-            let result = await Rules.addEnode(
+            let result = await nodeRulesContract.addEnode(
                 enodeId,
                 ip,    
                 Web3Utils.toBN(port)

--- a/migrations/3_deploy_node_ingress_rules_contract.js
+++ b/migrations/3_deploy_node_ingress_rules_contract.js
@@ -1,8 +1,9 @@
 const Web3Utils = require("web3-utils");
 const AllowlistUtils = require('../scripts/allowlist_utils');
 
-const NodeRules = artifacts.require("./NodeRules.sol");
+const Rules = artifacts.require("./NodeRules.sol");
 const NodeIngress = artifacts.require("./NodeIngress.sol");
+const NodeRulesListEternalStorage = artifacts.require("./NodeRulesListEternalStorage.sol");
 const Admin = artifacts.require("./Admin.sol");
 
 const adminContractName = Web3Utils.utf8ToHex("administration");
@@ -10,6 +11,8 @@ const rulesContractName = Web3Utils.utf8ToHex("rules");
 
 /* The address of the node ingress contract if pre deployed */
 let nodeIngress = process.env.NODE_INGRESS_CONTRACT_ADDRESS;
+/* The address of the node ingress contract if pre deployed */
+let nodeStorage = process.env.NODE_STORAGE_CONTRACT_ADDRESS;
 let retainCurrentRulesContract = AllowlistUtils.getRetainNodeRulesContract();
 
 module.exports = async(deployer, network) => {
@@ -39,14 +42,31 @@ module.exports = async(deployer, network) => {
     await nodeIngressInstance.setContractAddress(adminContractName, admin.address);
     console.log("   > Updated NodeIngress with Admin  address = " + admin.address);
 
-    await deployer.deploy(NodeRules, nodeIngress);
-    console.log("   > NodeRules deployed with NodeIngress.address = " + nodeIngress);
-    let nodeRulesContract = await NodeRules.deployed();
+    let nodeRulesContract = await Rules.deployed();
+
+    // STORAGE
+    var storageInstance;
+    if (! nodeStorage) {
+        // Only deploy if we haven't been provided a pre-deployed address
+        storageInstance = await deployer.deploy(NodeRulesListEternalStorage, nodeIngress);
+        console.log("   > Deployed NodeStorage contract to address = " + NodeRulesListEternalStorage.address);
+        nodeStorage = NodeRulesListEternalStorage.address;
+    } else {
+        // is there a storage already deployed
+        storageInstance = await NodeRulesListEternalStorage.at(nodeStorage);
+        console.log(">>> Using existing NodeStorage " + storageInstance.address);
+        // TODO check that this contract is a storage contract eg call a method
+    }
+
+    // rules -> storage
+    await deployer.deploy(Rules, nodeIngress, nodeStorage);
+    console.log("   > Rules deployed with NodeIngress.address = " + nodeIngress + "\n   > and storageAddress = " + nodeStorage);
+    console.log("   > Rules.address " + Rules.address);
 
     
 
-    await nodeIngressInstance.setContractAddress(rulesContractName, NodeRules.address);
-    console.log("   > Updated NodeIngress contract with NodeRules address = " + NodeRules.address);
+    await nodeIngressInstance.setContractAddress(rulesContractName, Rules.address);
+    console.log("   > Updated NodeIngress contract with NodeRules address = " + Rules.address);
 
     if(AllowlistUtils.isInitialAllowlistedNodesAvailable()) {
         console.log("   > Adding Initial Allowlisted eNodes ...");

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     ]
   },
   "description": "Smart contracts and dapp implementing EEA spec onchain permissioning",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "main": "README.md",
   "directories": {
     "test": "test"

--- a/test/test-node-ingress-proxy.js
+++ b/test/test-node-ingress-proxy.js
@@ -1,7 +1,7 @@
 const NodeIngress = artifacts.require('NodeIngress.sol');
 const NodeRules = artifacts.require('NodeRules.sol');
 const Admin = artifacts.require('Admin.sol');
-const RulesStorage = artifacts.require('NodeRulesListEternalStorage.sol');
+const RulesStorage = artifacts.require('NodeStorage.sol');
 
 const RULES='0x72756c6573000000000000000000000000000000000000000000000000000000';
 const ADMIN='0x61646d696e697374726174696f6e000000000000000000000000000000000000';

--- a/test/test-node-ingress-proxy.js
+++ b/test/test-node-ingress-proxy.js
@@ -101,7 +101,7 @@ contract ('NodeIngress (proxying permissioning check to rules contract)', () => 
     // Verify that the newly registered contract is the correct version
     let contract = await NodeRules.at(result);
     result = await contract.getContractVersion();
-    assert.equal(web3.utils.toDecimal(result), 1000000, 'Rules contract is NOT the correct version');
+    assert.equal(web3.utils.toDecimal(result), 3000000, 'Rules contract is NOT the correct version');
 
     // Verify that the node is permitted
     result = await nodeIngressContract.connectionAllowed(enode1, node1Host, node1Port);

--- a/test/test-node-ingress.js
+++ b/test/test-node-ingress.js
@@ -37,7 +37,7 @@ contract ("Node Ingress (no contracts registered)", (accounts) => {
         let permitted = await nodeIngressContract.connectionAllowed(enodeId, nodeHost, nodePort);
         assert.equal(permitted, false, "expected connectionAllowed to return false");
     });
-7
+
     it("Should return empty value if NodeRules contract has not been registered", async () => {
         let result = await nodeIngressContract.getContractAddress(RULES);
         assert.equal(result, "0x0000000000000000000000000000000000000000", "NodeRules contract should NOT already be registered");

--- a/test/test-node-ingress.js
+++ b/test/test-node-ingress.js
@@ -1,7 +1,7 @@
 const NodeIngressContract = artifacts.require("NodeIngress.sol");
 const NodeRules = artifacts.require("NodeRules.sol");
 const AdminContract = artifacts.require("Admin.sol");
-const RulesStorage = artifacts.require('NodeRulesListEternalStorage.sol');
+const RulesStorage = artifacts.require('NodeStorage.sol');
 
 const RULES="0x72756c6573000000000000000000000000000000000000000000000000000000";
 const ADMIN="0x61646d696e697374726174696f6e000000000000000000000000000000000000";

--- a/test/test-node-ingress.js
+++ b/test/test-node-ingress.js
@@ -1,6 +1,7 @@
 const NodeIngressContract = artifacts.require("NodeIngress.sol");
-const NodeRulesContract = artifacts.require("NodeRules.sol");
+const NodeRules = artifacts.require("NodeRules.sol");
 const AdminContract = artifacts.require("Admin.sol");
+const RulesStorage = artifacts.require('NodeRulesListEternalStorage.sol');
 
 const RULES="0x72756c6573000000000000000000000000000000000000000000000000000000";
 const ADMIN="0x61646d696e697374726174696f6e000000000000000000000000000000000000";
@@ -16,12 +17,18 @@ contract ("Node Ingress (no contracts registered)", (accounts) => {
     let nodeIngressContract;
     let nodeRulesContract;
     let adminContract;
+    let storageContract;
 
     beforeEach("create a new contract for each test", async () => {
         nodeIngressContract = await NodeIngressContract.new();
         adminContract = await AdminContract.new();
-        nodeRulesContract = await NodeRulesContract.new(nodeIngressContract.address);
-    })
+
+        // set the storage
+        storageContract = await RulesStorage.new(nodeIngressContract.address);
+        console.log("   >>> Storage contract deployed with address = " + storageContract.address);
+        
+        nodeRulesContract = await NodeRules.new(nodeIngressContract.address, storageContract.address);
+        })
 
     it("should forbid any connection if rules contract has not been registered", async () => {
         result = await nodeIngressContract.getContractAddress(RULES);
@@ -30,7 +37,7 @@ contract ("Node Ingress (no contracts registered)", (accounts) => {
         let permitted = await nodeIngressContract.connectionAllowed(enodeId, nodeHost, nodePort);
         assert.equal(permitted, false, "expected connectionAllowed to return false");
     });
-
+7
     it("Should return empty value if NodeRules contract has not been registered", async () => {
         let result = await nodeIngressContract.getContractAddress(RULES);
         assert.equal(result, "0x0000000000000000000000000000000000000000", "NodeRules contract should NOT already be registered");
@@ -161,13 +168,23 @@ contract("Ingress contract", (accounts) => {
     let nodeIngressContract;
     let nodeRulesContract;
     let adminContract;
+    let storageContract;
 
     beforeEach("Setup contract registry", async () => {
         nodeIngressContract = await NodeIngressContract.new();
         adminContract = await AdminContract.new();
         await nodeIngressContract.setContractAddress(ADMIN, adminContract.address);
-        nodeRulesContract = await NodeRulesContract.new(nodeIngressContract.address);
+
+        // set the storage
+        storageContract = await RulesStorage.new(nodeIngressContract.address);
+        console.log("   >>> Storage contract deployed with address = " + storageContract.address);
+        
+        nodeRulesContract = await NodeRules.new(nodeIngressContract.address, storageContract.address);
+    
         await nodeIngressContract.setContractAddress(RULES, nodeRulesContract.address);
+        // set rules as the storage owner
+        await storageContract.upgradeVersion(nodeRulesContract.address);
+        console.log("   >>> Set storage owner to Rules.address");
     })
 
     it("Should not allow an unauthorized account to perform administration operations", async () => {
@@ -262,7 +279,7 @@ contract("Ingress contract", (accounts) => {
     it("Should only trigger NodeRules update events when issued from NodeRules contract", async () => {
         let result;
 
-        const acProxy = await NodeRulesContract.new(nodeIngressContract.address);
+        const acProxy = await NodeRules.new(nodeIngressContract.address, storageContract.address);
 
         // Register the contracts
         await nodeIngressContract.setContractAddress(RULES, nodeRulesContract.address);

--- a/test/test-node-rules-events.js
+++ b/test/test-node-rules-events.js
@@ -1,5 +1,6 @@
 const NodeIngressContract = artifacts.require('NodeIngress.sol');
-const NodeRulesContract = artifacts.require('NodeRules.sol');
+const NodeRules = artifacts.require('NodeRules.sol');
+const RulesStorage = artifacts.require('NodeRulesListEternalStorage.sol');
 const AdminContract = artifacts.require('Admin.sol');
 
 // Contract keys
@@ -24,8 +25,16 @@ contract("NodeRules (Events)", () => {
     adminContract = await AdminContract.new();
     await nodeIngressContract.setContractAddress(ADMIN_NAME, adminContract.address);
 
-    nodeRulesContract = await NodeRulesContract.new(nodeIngressContract.address);
+    // set the storage
+    storageContract = await RulesStorage.new(nodeIngressContract.address);
+    console.log("   >>> Storage contract deployed with address = " + storageContract.address);
+    
+    nodeRulesContract = await NodeRules.new(nodeIngressContract.address, storageContract.address);
     await nodeIngressContract.setContractAddress(RULES_NAME, nodeRulesContract.address);
+
+    // set rules as the storage owner
+    await storageContract.upgradeVersion(nodeRulesContract.address);
+    console.log("   >>> Set storage owner to Rules.address");
   })
 
   it('should emit events when node added', async () => {

--- a/test/test-node-rules-events.js
+++ b/test/test-node-rules-events.js
@@ -1,6 +1,6 @@
 const NodeIngressContract = artifacts.require('NodeIngress.sol');
 const NodeRules = artifacts.require('NodeRules.sol');
-const RulesStorage = artifacts.require('NodeRulesListEternalStorage.sol');
+const RulesStorage = artifacts.require('NodeStorage.sol');
 const AdminContract = artifacts.require('Admin.sol');
 
 // Contract keys

--- a/test/test-node-rules-list.js
+++ b/test/test-node-rules-list.js
@@ -2,7 +2,7 @@ const BN = web3.utils.BN;
 const { AddressZero } = require("ethers/constants");
 
 const RulesList = artifacts.require('ExposedNodeRulesList.sol');
-const RulesStorage = artifacts.require('NodeRulesListEternalStorage.sol');
+const RulesStorage = artifacts.require('NodeStorage.sol');
 
 const enode1 = "9bd359fdc3a2ed5df436c3d8914b1532740128929892092b7fcb320c1b62f375"
 + "2e1092b7fcb320c1b62f3759bd359fdc3a2ed5df436c3d8914b1532740128929";

--- a/test/test-node-rules-list.js
+++ b/test/test-node-rules-list.js
@@ -1,5 +1,8 @@
 const BN = web3.utils.BN;
-const NodeRulesList = artifacts.require('ExposedNodeRulesList.sol');
+const { AddressZero } = require("ethers/constants");
+
+const RulesList = artifacts.require('ExposedNodeRulesList.sol');
+const RulesStorage = artifacts.require('NodeRulesListEternalStorage.sol');
 
 const enode1 = "9bd359fdc3a2ed5df436c3d8914b1532740128929892092b7fcb320c1b62f375"
 + "2e1092b7fcb320c1b62f3759bd359fdc3a2ed5df436c3d8914b1532740128929";
@@ -19,7 +22,15 @@ contract("NodeRulesList (list manipulation)", async () => {
   let rulesListContract;
 
   beforeEach(async () => {
-    rulesListContract = await NodeRulesList.new();
+    rulesListContract = await RulesList.new();
+    // initialize the storage
+    storageContract = await RulesStorage.new(AddressZero);
+    console.log("   >>> Storage contract deployed with address = " + storageContract.address);
+    // set rules -> storage
+    rulesListContract._setStorage(storageContract.address);
+    // set rules as the storage owner: storage -> rules
+    await storageContract.upgradeVersion(rulesListContract.address);
+    console.log("   >>> Set storage owner to Rules.address " + rulesListContract.address);
   });
 
   it("should calculate same key for same enode", async () => {
@@ -118,11 +129,5 @@ contract("NodeRulesList (list manipulation)", async () => {
     assert.equal(size, 0);
     exists = await rulesListContract._exists(enode1, node1Host, node1Port);
     assert.notOk(exists);
-  });
-
-  it("get by index on empty list should return undefined", async () => {
-    let node = await rulesListContract.allowlist[0];
-
-    assert.isUndefined(node);
   });
 });

--- a/test/test-node-rules-permissioning.js
+++ b/test/test-node-rules-permissioning.js
@@ -123,7 +123,7 @@ contract("NodeRules (Permissioning)", (accounts) => {
     }
   });
 
-  it('should not allow non-admin account to remove node to list', async () => {
+  it('should not allow non-admin account to remove node from list', async () => {
     try {
       await nodeRulesContract.addEnode(enode1, node1Host, node1Port, { from: accounts[1] });
       expect.fail(null, null, "Modifier was not enforced")

--- a/test/test-node-rules-permissioning.js
+++ b/test/test-node-rules-permissioning.js
@@ -1,5 +1,6 @@
 const NodeIngressContract = artifacts.require('NodeIngress.sol');
-const NodeRulesContract = artifacts.require('NodeRules.sol');
+const NodeRules = artifacts.require('NodeRules.sol');
+const RulesStorage = artifacts.require('NodeRulesListEternalStorage.sol');
 const AdminContract = artifacts.require('Admin.sol');
 
 // Contract keys
@@ -27,6 +28,7 @@ contract("NodeRules (Permissioning)", (accounts) => {
   let nodeIngressContract;
   let nodeRulesContract;
   let adminContract;
+  let storageContract;
 
   before(async () => {
     nodeIngressContract = await NodeIngressContract.new();
@@ -34,8 +36,16 @@ contract("NodeRules (Permissioning)", (accounts) => {
     adminContract = await AdminContract.new();
     await nodeIngressContract.setContractAddress(ADMIN_NAME, adminContract.address);
 
-    nodeRulesContract = await NodeRulesContract.new(nodeIngressContract.address);
+    // set the storage
+    storageContract = await RulesStorage.new(nodeIngressContract.address);
+    console.log("   >>> Storage contract deployed with address = " + storageContract.address);
+    
+    nodeRulesContract = await NodeRules.new(nodeIngressContract.address, storageContract.address);
     await nodeIngressContract.setContractAddress(RULES_NAME, nodeRulesContract.address);
+
+    // set rules as the storage owner
+    await storageContract.upgradeVersion(nodeRulesContract.address);
+    console.log("   >>> Set storage owner to Rules.address");
   });
 
   it('should NOT permit node when list is empty', async () => {

--- a/test/test-node-rules-permissioning.js
+++ b/test/test-node-rules-permissioning.js
@@ -1,6 +1,6 @@
 const NodeIngressContract = artifacts.require('NodeIngress.sol');
 const NodeRules = artifacts.require('NodeRules.sol');
-const RulesStorage = artifacts.require('NodeRulesListEternalStorage.sol');
+const RulesStorage = artifacts.require('NodeStorage.sol');
 const AdminContract = artifacts.require('Admin.sol');
 
 // Contract keys

--- a/test/test-node-rules-read-only-mode.js
+++ b/test/test-node-rules-read-only-mode.js
@@ -1,6 +1,6 @@
 const NodeIngress = artifacts.require('NodeIngress.sol');
 const NodeRules = artifacts.require('NodeRules.sol');
-const RulesStorage = artifacts.require('NodeRulesListEternalStorage.sol');
+const RulesStorage = artifacts.require('NodeStorage.sol');
 const Admin = artifacts.require('Admin.sol');
 
 var enode1 = "9bd359fdc3a2ed5df436c3d8914b1532740128929892092b7fcb320c1b62f375"

--- a/test/test-node-rules-read-only-mode.js
+++ b/test/test-node-rules-read-only-mode.js
@@ -1,5 +1,6 @@
 const NodeIngress = artifacts.require('NodeIngress.sol');
 const NodeRules = artifacts.require('NodeRules.sol');
+const RulesStorage = artifacts.require('NodeRulesListEternalStorage.sol');
 const Admin = artifacts.require('Admin.sol');
 
 var enode1 = "9bd359fdc3a2ed5df436c3d8914b1532740128929892092b7fcb320c1b62f375"
@@ -17,7 +18,16 @@ contract('NodeRules (Read-only mode)', () => {
 
   beforeEach(async () => {
     nodeIngressContract = await NodeIngress.deployed();
-    nodeRulesContract = await NodeRules.new(NodeIngress.address);
+
+    // set the storage
+    storageContract = await RulesStorage.new(nodeIngressContract.address);
+    console.log("   >>> Storage contract deployed with address = " + storageContract.address);
+    
+    nodeRulesContract = await NodeRules.new(nodeIngressContract.address, storageContract.address);
+
+    // set rules as the storage owner
+    await storageContract.upgradeVersion(nodeRulesContract.address);
+    console.log("   >>> Set storage owner to Rules.address");
   })
 
   it("should toggle read-only flag on enter/exit read-mode method invocation", async () => {


### PR DESCRIPTION
Truffle tests are passing locally.
No Dapp changes have been made.

- [x] add test that deploys storage & rules, add some nodes, then upgrade rules and assert that storage has not changed
- [x] do not redeploy storage contract by default
- [x] allow env var for storage contract address - same as ingress contracts
- [x] test dapp locally on ganache - any changes required?
- [x] test dapp locally on besu with contracts in genesis file
- [x] does INITIAL_ALLOWLISTED_NODES env var still work with this storage contract?