### PR TITLE
mark all existing admins as able to create contracts when migrating

### DIFF
--- a/contracts/AccountRules.sol
+++ b/contracts/AccountRules.sol
@@ -99,11 +99,11 @@ contract AccountRules is AccountRulesProxy, AccountRulesList {
         emit AccountRemoved(removed, account);
         return removed;
     }
-    
+
     function setCreateContractPermission(address _account, bool _allowed) public onlyAdmin returns (bool){
         return setCanCreateContracts(_account, _allowed);
     }
-    
+
     function getCreateContractPermission(address _account) public onlyAdmin returns (bool){
         return getCanCreateContracts(_account);
     }

--- a/contracts/AccountStorage.sol
+++ b/contracts/AccountStorage.sol
@@ -17,7 +17,7 @@ contract AccountStorage {
 
     address[] public allowlist;
     mapping (address => uint256) private indexOf; //1 based indexing. 0 means non-existent
-    mapping (address => bool) private createContractPermissions; 
+    mapping (address => bool) private createContractPermissions;
 
     constructor (AccountIngress _ingressContract) public {
         ingressContract = _ingressContract;

--- a/migrations/4_deploy_account_ingress_rules_contract.js
+++ b/migrations/4_deploy_account_ingress_rules_contract.js
@@ -72,17 +72,22 @@ module.exports = async(deployer, network) => {
     await storageInstance.upgradeVersion(Rules.address);
     console.log("   >>> Set storage owner to Rules.address " + Rules.address);
 
+    let createdOrMigratedAccounts;
     if (AllowlistUtils.isInitialAllowlistedAccountsAvailable()) {
         console.log("   > Adding Initial Allowlisted Accounts ...");
-        let allowlistedAccounts = AllowlistUtils.getInitialAllowlistedAccounts();
-        if (allowlistedAccounts.length > 0) {
+        createdOrMigratedAccounts = AllowlistUtils.getInitialAllowlistedAccounts();
+        if (createdOrMigratedAccounts.length > 0) {
             await accountRulesContract.addAccounts(allowlistedAccounts);
             console.log ("   > Initial Allowlisted Accounts added: " + allowlistedAccounts);
-            // set these accounts to be able to deploy contracts
-            await accountRulesContract.setCreateContractPermission(allowlistedAccounts[0], true);
-            console.log(">>> gave contract creation permission to " + allowlistedAccounts[0]);
         }
-        
+    }else{
+        createdOrMigratedAccounts = await accountRulesContract.getAccounts();
+    }
+
+    // set these accounts to be able to deploy contracts
+    for (const account of createdOrMigratedAccounts) {
+        await accountRulesContract.setCreateContractPermission(account, true);
+        console.log(">>> gave contract creation permission to " + account);
     }
 
     await accountIngressInstance.setContractAddress(rulesContractName, Rules.address);


### PR DESCRIPTION
Without this fix, admins would not be able to create new contracts after `AccountRules` is deployed and activated. While this could be manually fixed, it prevents using truffle to migrate further contracts directly after deploying `AccountRules`.

It also fixes a bug were the old code would only give the first admin the list contract creation permission instead of giving it to all admins.

Signed-off-by: Taccat Isid <taccatisid@protonmail.com>
(cherry picked from commit 682ba1045709177a54064c337a264d97f7da9d49)